### PR TITLE
fix(MenuItemMapper): correção do metodo toResponseDTO, faltava passar…

### DIFF
--- a/ms-users/src/main/java/com/fiap/tech_challenge/parte1/ms_users/infrastructure/mapper/MenuItemMapper.java
+++ b/ms-users/src/main/java/com/fiap/tech_challenge/parte1/ms_users/infrastructure/mapper/MenuItemMapper.java
@@ -51,7 +51,8 @@ public class MenuItemMapper implements IMenuItemMapper {
                 menuItem.getDescription(),
                 menuItem.getPrice(),
                 menuItem.getAvailableOnlyOnSite(),
-                menuItem.getImagePath()
+                menuItem.getImagePath(),
+                menuItem.getRestaurantId()
         );
     }
 


### PR DESCRIPTION
# Correção de erro

fiz algumas alterações no MenuItemMapper, no método  toResponseDTO, onde faltava somente passar um parâmetro que é o getRestauranteId para que o construtor funcionasse corretamente.